### PR TITLE
feat: add backend service with book CRUD

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/backend/books.test.js
+++ b/backend/books.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const app = require('./index');
+
+describe('Books API', () => {
+  it('should return empty list initially', async () => {
+    const res = await request(app).get('/books');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('should create a book', async () => {
+    const res = await request(app)
+      .post('/books')
+      .send({ title: 'Book1', author: 'Author1' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toMatchObject({ id: 1, title: 'Book1', author: 'Author1' });
+  });
+
+  it('should list books', async () => {
+    const res = await request(app).get('/books');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('should get a book by id', async () => {
+    const res = await request(app).get('/books/1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.title).toBe('Book1');
+  });
+
+  it('should update a book', async () => {
+    const res = await request(app)
+      .put('/books/1')
+      .send({ title: 'Updated', author: 'Author2' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.title).toBe('Updated');
+    expect(res.body.author).toBe('Author2');
+  });
+
+  it('should delete a book', async () => {
+    const res = await request(app).delete('/books/1');
+    expect(res.statusCode).toBe(204);
+    const res2 = await request(app).get('/books/1');
+    expect(res2.statusCode).toBe(404);
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const app = express();
+
+app.use(express.json());
+
+let books = [];
+let nextId = 1;
+
+// Get all books
+app.get('/books', (req, res) => {
+  res.json(books);
+});
+
+// Get a book by id
+app.get('/books/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const book = books.find(b => b.id === id);
+  if (!book) {
+    return res.status(404).json({ error: 'Book not found' });
+  }
+  res.json(book);
+});
+
+// Create a new book
+app.post('/books', (req, res) => {
+  const { title, author } = req.body;
+  if (!title) {
+    return res.status(400).json({ error: 'Title is required' });
+  }
+  const book = { id: nextId++, title, author };
+  books.push(book);
+  res.status(201).json(book);
+});
+
+// Update a book
+app.put('/books/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const book = books.find(b => b.id === id);
+  if (!book) {
+    return res.status(404).json({ error: 'Book not found' });
+  }
+  const { title, author } = req.body;
+  if (title !== undefined) book.title = title;
+  if (author !== undefined) book.author = author;
+  res.json(book);
+});
+
+// Delete a book
+app.delete('/books/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const index = books.findIndex(b => b.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Book not found' });
+  }
+  books.splice(index, 1);
+  res.status(204).send();
+});
+
+module.exports = app;
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Book service with Express",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  }
+}


### PR DESCRIPTION
## Summary
- implement Express server with CRUD endpoints for books
- add Jest tests and package scripts
- include Dockerfile for containerizing the backend

## Testing
- `npm test` *(fails: jest not found)*
- `npm start` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_689222cf9dbc83239aafa8f6e2a033bf