### PR TITLE
feat: add react frontend with book crud

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+package-lock.json

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install && npm install -g serve
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["serve", "-s", "build"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1",
+    "react-scripts": "5.0.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.3.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Books</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import BookList from './BookList';
+import BookForm from './BookForm';
+
+function App() {
+  const [books, setBooks] = useState([]);
+  const [editing, setEditing] = useState(null);
+
+  const loadBooks = () => {
+    fetch('/books')
+      .then(res => res.json())
+      .then(setBooks);
+  };
+
+  useEffect(() => {
+    loadBooks();
+  }, []);
+
+  const handleCreate = data => {
+    fetch('/books', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).then(loadBooks);
+  };
+
+  const handleUpdate = (id, data) => {
+    fetch(`/books/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).then(() => {
+      setEditing(null);
+      loadBooks();
+    });
+  };
+
+  const handleDelete = id => {
+    fetch(`/books/${id}`, { method: 'DELETE' }).then(loadBooks);
+  };
+
+  return (
+    <div>
+      <h1>Books</h1>
+      <BookForm
+        onSubmit={editing ? data => handleUpdate(editing.id, data) : handleCreate}
+        initialData={editing}
+      />
+      <BookList books={books} onEdit={setEditing} onDelete={handleDelete} />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import App from './App';
+
+global.fetch = jest.fn();
+
+afterEach(() => {
+  fetch.mockClear();
+});
+
+test('create, update, and delete a book', async () => {
+  // initial load
+  fetch.mockResolvedValueOnce({
+    json: async () => []
+  });
+
+  render(<App />);
+  expect(fetch).toHaveBeenCalledWith('/books');
+
+  // create
+  fetch.mockResolvedValueOnce({
+    json: async () => ({ id: 1, title: 'Test', author: 'Author' }),
+    status: 201
+  });
+  fetch.mockResolvedValueOnce({
+    json: async () => [{ id: 1, title: 'Test', author: 'Author' }]
+  });
+
+  fireEvent.change(screen.getByPlaceholderText(/Title/i), {
+    target: { value: 'Test' }
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Author/i), {
+    target: { value: 'Author' }
+  });
+  fireEvent.click(screen.getByText(/Create/i));
+
+  await waitFor(() => screen.getByText('Test by Author'));
+
+  // update
+  fetch.mockResolvedValueOnce({
+    json: async () => ({ id: 1, title: 'Updated', author: 'Author' })
+  });
+  fetch.mockResolvedValueOnce({
+    json: async () => [{ id: 1, title: 'Updated', author: 'Author' }]
+  });
+
+  fireEvent.click(screen.getByText(/Edit/i));
+  fireEvent.change(screen.getByPlaceholderText(/Title/i), {
+    target: { value: 'Updated' }
+  });
+  fireEvent.click(screen.getByText(/Update/i));
+  await waitFor(() => screen.getByText('Updated by Author'));
+
+  // delete
+  fetch.mockResolvedValueOnce({ status: 204 });
+  fetch.mockResolvedValueOnce({
+    json: async () => []
+  });
+  fireEvent.click(screen.getByText(/Delete/i));
+  await waitFor(() => expect(screen.queryByText('Updated by Author')).toBeNull());
+});

--- a/frontend/src/BookForm.js
+++ b/frontend/src/BookForm.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+
+export default function BookForm({ onSubmit, initialData }) {
+  const [title, setTitle] = useState('');
+  const [author, setAuthor] = useState('');
+
+  useEffect(() => {
+    if (initialData) {
+      setTitle(initialData.title || '');
+      setAuthor(initialData.author || '');
+    } else {
+      setTitle('');
+      setAuthor('');
+    }
+  }, [initialData]);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onSubmit({ title, author });
+    if (!initialData) {
+      setTitle('');
+      setAuthor('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input placeholder="Title" value={title} onChange={e => setTitle(e.target.value)} />
+      <input placeholder="Author" value={author} onChange={e => setAuthor(e.target.value)} />
+      <button type="submit">{initialData ? 'Update' : 'Create'}</button>
+    </form>
+  );
+}

--- a/frontend/src/BookList.js
+++ b/frontend/src/BookList.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function BookList({ books, onEdit, onDelete }) {
+  return (
+    <ul>
+      {books.map(book => (
+        <li key={book.id}>
+          {book.title} by {book.author || 'Unknown'}
+          <button onClick={() => onEdit(book)}>Edit</button>
+          <button onClick={() => onDelete(book.id)}>Delete</button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- scaffold React frontend for book CRUD operations
- add UI tests with React Testing Library
- containerize frontend with Dockerfile

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: sh: 1: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892243c57e083238807b03cf92a5f25