### PR TITLE
Add Jenkins pipeline for build, test, and deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,46 @@
+pipeline {
+  agent any
+
+  stages {
+    stage('Build') {
+      steps {
+        dir('backend') {
+          sh 'npm ci'
+          sh 'docker build -t backend:latest .'
+        }
+        dir('frontend') {
+          sh 'npm ci'
+          sh 'npm run build'
+          sh 'docker build -t frontend:latest .'
+        }
+      }
+    }
+
+    stage('Unit Tests') {
+      steps {
+        parallel(
+          failFast: true,
+          backend: {
+            dir('backend') {
+              sh 'npm test'
+            }
+          },
+          frontend: {
+            dir('frontend') {
+              sh 'CI=true npm test'
+            }
+          }
+        )
+      }
+    }
+
+    stage('Deploy') {
+      steps {
+        sh 'opentofu init'
+        sh 'opentofu apply -auto-approve'
+        sh 'helm upgrade --install backend ./helm/backend'
+        sh 'helm upgrade --install frontend ./helm/frontend'
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Jenkinsfile with build, unit test, and deployment stages
- run backend and frontend tests in parallel and deploy using OpenTofu and Helm

## Testing
- `cd backend && npm test -- --runInBand`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68922775a5988323aefd6860eecc0876