### PR TITLE
Add OpenTofu modules for infra and apps namespaces

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,22 @@
+# Infrastructure Modules
+
+This directory contains OpenTofu modules for Kubernetes namespaces used by the project.
+
+## Modules
+
+### `infra`
+Creates the `infra` namespace for cluster infrastructure components.
+
+### `apps`
+Creates the `apps` namespace for application workloads.
+
+Each module exposes a `name` variable to override the namespace and outputs `namespace_name`.
+
+## Testing
+
+Unit tests are provided for each module using `tofu test`.
+Run tests from the module directory:
+
+```bash
+tofu test
+```

--- a/infrastructure/apps/README.md
+++ b/infrastructure/apps/README.md
@@ -1,0 +1,25 @@
+# Apps Namespace Module
+
+Creates a Kubernetes namespace intended for application workloads.
+
+## Usage
+
+```hcl
+module "apps_namespace" {
+  source = "./apps"
+  # Optional override
+  # name = "apps"
+}
+```
+
+## Variables
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | `"apps"` | Name of the Kubernetes namespace. |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `namespace_name` | The name of the created namespace. |

--- a/infrastructure/apps/main.tf
+++ b/infrastructure/apps/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+
+resource "kubernetes_namespace" "this" {
+  metadata {
+    name = var.name
+  }
+}

--- a/infrastructure/apps/outputs.tf
+++ b/infrastructure/apps/outputs.tf
@@ -1,0 +1,4 @@
+output "namespace_name" {
+  description = "The name of the created namespace."
+  value       = kubernetes_namespace.this.metadata[0].name
+}

--- a/infrastructure/apps/tests/default.tftest.hcl
+++ b/infrastructure/apps/tests/default.tftest.hcl
@@ -1,0 +1,15 @@
+test {
+  name = "apps namespace default"
+
+  mock_provider "kubernetes" {}
+
+  module "namespace" {
+    source    = ".."
+    providers = { kubernetes = mock.kubernetes }
+  }
+
+  assert {
+    condition     = module.namespace.namespace_name == "apps"
+    error_message = "Expected namespace name to be apps"
+  }
+}

--- a/infrastructure/apps/variables.tf
+++ b/infrastructure/apps/variables.tf
@@ -1,0 +1,5 @@
+variable "name" {
+  description = "Name of the Kubernetes namespace."
+  type        = string
+  default     = "apps"
+}

--- a/infrastructure/infra/README.md
+++ b/infrastructure/infra/README.md
@@ -1,0 +1,25 @@
+# Infra Namespace Module
+
+Creates a Kubernetes namespace intended for infrastructure components.
+
+## Usage
+
+```hcl
+module "infra_namespace" {
+  source = "./infra"
+  # Optional override
+  # name = "infra"
+}
+```
+
+## Variables
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | `"infra"` | Name of the Kubernetes namespace. |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `namespace_name` | The name of the created namespace. |

--- a/infrastructure/infra/main.tf
+++ b/infrastructure/infra/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+
+resource "kubernetes_namespace" "this" {
+  metadata {
+    name = var.name
+  }
+}

--- a/infrastructure/infra/outputs.tf
+++ b/infrastructure/infra/outputs.tf
@@ -1,0 +1,4 @@
+output "namespace_name" {
+  description = "The name of the created namespace."
+  value       = kubernetes_namespace.this.metadata[0].name
+}

--- a/infrastructure/infra/tests/default.tftest.hcl
+++ b/infrastructure/infra/tests/default.tftest.hcl
@@ -1,0 +1,15 @@
+test {
+  name = "infra namespace default"
+
+  mock_provider "kubernetes" {}
+
+  module "namespace" {
+    source    = ".."
+    providers = { kubernetes = mock.kubernetes }
+  }
+
+  assert {
+    condition     = module.namespace.namespace_name == "infra"
+    error_message = "Expected namespace name to be infra"
+  }
+}

--- a/infrastructure/infra/variables.tf
+++ b/infrastructure/infra/variables.tf
@@ -1,0 +1,5 @@
+variable "name" {
+  description = "Name of the Kubernetes namespace."
+  type        = string
+  default     = "infra"
+}


### PR DESCRIPTION
## Summary
- add OpenTofu modules creating `infra` and `apps` Kubernetes namespaces
- document variables, outputs, and usage for each module
- include `tofu test` specs verifying module defaults

## Testing
- `tofu test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6892277a79108323b5f235eda3e69bb2