### PR TITLE
feat: add helm charts for services with monitoring

### DIFF
--- a/helm/backend/Chart.yaml
+++ b/helm/backend/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: backend
+description: Backend service chart
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/backend/templates/configmap.yaml
+++ b/helm/backend/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-config
+  labels:
+    app: {{ .Chart.Name }}
+data:
+  APP_ENV: "production"

--- a/helm/backend/templates/deployment.yaml
+++ b/helm/backend/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name }}-config
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/backend/templates/grafana-dashboard-configmap.yaml
+++ b/helm/backend/templates/grafana-dashboard-configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-grafana-dashboard
+  labels:
+    grafana_dashboard: "1"
+data:
+  backend-dashboard.json: |-
+    {
+      "title": "Backend Overview",
+      "panels": [
+        {
+          "type": "graph",
+          "title": "HTTP Request Rate",
+          "targets": [
+            {
+              "expr": "sum(rate(http_requests_total[5m]))",
+              "legendFormat": "req/s"
+            }
+          ],
+          "datasource": "Prometheus",
+          "id": 1
+        }
+      ],
+      "schemaVersion": 16,
+      "version": 1
+    }

--- a/helm/backend/templates/service.yaml
+++ b/helm/backend/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.metrics.port }}"
+    prometheus.io/path: /metrics
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Chart.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics

--- a/helm/backend/values.yaml
+++ b/helm/backend/values.yaml
@@ -1,0 +1,15 @@
+replicaCount: 1
+
+image:
+  repository: backend
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3000
+
+metrics:
+  port: 9100
+
+resources: {}

--- a/helm/frontend/Chart.yaml
+++ b/helm/frontend/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: frontend
+description: Frontend service chart
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/frontend/templates/configmap.yaml
+++ b/helm/frontend/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-config
+  labels:
+    app: {{ .Chart.Name }}
+data:
+  APP_ENV: "production"

--- a/helm/frontend/templates/deployment.yaml
+++ b/helm/frontend/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name }}-config
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/frontend/templates/grafana-dashboard-configmap.yaml
+++ b/helm/frontend/templates/grafana-dashboard-configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-grafana-dashboard
+  labels:
+    grafana_dashboard: "1"
+data:
+  frontend-dashboard.json: |-
+    {
+      "title": "Frontend Overview",
+      "panels": [
+        {
+          "type": "graph",
+          "title": "HTTP Request Rate",
+          "targets": [
+            {
+              "expr": "sum(rate(http_requests_total[5m]))",
+              "legendFormat": "req/s"
+            }
+          ],
+          "datasource": "Prometheus",
+          "id": 1
+        }
+      ],
+      "schemaVersion": 16,
+      "version": 1
+    }

--- a/helm/frontend/templates/service.yaml
+++ b/helm/frontend/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.metrics.port }}"
+    prometheus.io/path: /metrics
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Chart.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics

--- a/helm/frontend/values.yaml
+++ b/helm/frontend/values.yaml
@@ -1,0 +1,15 @@
+replicaCount: 1
+
+image:
+  repository: frontend
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3000
+
+metrics:
+  port: 9100
+
+resources: {}


### PR DESCRIPTION
## Summary
- add backend and frontend Helm charts with deployment, service and config templates
- expose metrics ports and annotate services for Prometheus
- bundle default Grafana dashboards through ConfigMaps

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_6892277e9030832386e6e61152b9ee31