### PR TITLE
Add namespace setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,44 @@ One for the infra an other for the apps that will be deployed. The pipelines in 
 OpenTofu need to have automated tests as well, all apps deploed need to be integrated with Grafana
 and Prometheus by default.
 
+## Cluster and Namespace Setup
+
+Use the helper script to start a local Kubernetes cluster and create the
+required namespaces:
+
+```bash
+scripts/setup-namespaces.sh
+```
+
+The script:
+
+* starts a Minikube cluster if one is not running
+* creates separate namespaces for infrastructure (`infra`) and applications (`apps`)
+* applies OpenTofu configuration to the `infra` namespace
+* deploys Helm charts into the `apps` namespace
+
+### Manual steps
+
+The script above simply automates the following commands:
+
+```bash
+# Start a local cluster
+minikube start
+
+# Create namespaces
+kubectl create namespace infra
+kubectl create namespace apps
+
+# Apply infrastructure with OpenTofu
+cd infrastructure
+tofu init
+tofu apply -var="namespace=infra"
+
+# Deploy application with Helm
+helm upgrade --install app-release helm/app-chart --namespace apps --create-namespace
+```
+
+Using different namespaces ensures a clear separation between infrastructure
+components and application workloads.
+
 

--- a/scripts/setup-namespaces.sh
+++ b/scripts/setup-namespaces.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create or ensure namespaces for infrastructure and applications and apply deployments.
+# Requirements: minikube, kubectl, opentofu, helm
+
+INFRA_NS="infra"
+APP_NS="apps"
+
+# Start a local cluster if one is not running
+if ! minikube status >/dev/null 2>&1; then
+  echo "Starting Minikube cluster..."
+  minikube start
+fi
+
+# Create namespaces if they do not exist
+kubectl get namespace "$INFRA_NS" >/dev/null 2>&1 || kubectl create namespace "$INFRA_NS"
+kubectl get namespace "$APP_NS" >/dev/null 2>&1 || kubectl create namespace "$APP_NS"
+
+# Apply infrastructure with OpenTofu
+if [ -d "infrastructure" ]; then
+  pushd infrastructure >/dev/null
+  tofu init
+  tofu apply -var="namespace=${INFRA_NS}" -auto-approve
+  popd >/dev/null
+else
+  echo "No infrastructure directory found; skipping OpenTofu apply"
+fi
+
+# Deploy application with Helm
+if [ -d "helm" ]; then
+  helm upgrade --install app-release helm/app-chart --namespace "$APP_NS" --create-namespace
+else
+  echo "No Helm chart directory found; skipping Helm deployment"
+fi


### PR DESCRIPTION
## Summary
- add script to start Minikube, create infra/apps namespaces, and run OpenTofu and Helm
- document namespace separation and manual deployment commands

## Testing
- `CI=true npm test --prefix backend`
- `CI=true npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68922a51e6588323b57ff4a612dcd05c