### PR TITLE
docs: add setup and contribution guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing Guidelines
+
+Thank you for considering a contribution to this project. The following
+standards help us maintain a clean and reliable codebase.
+
+## Coding Standards
+- Use clear, self-documenting code with consistent formatting.
+- Prefer JavaScript ES6+ features and include tests for new functionality.
+- Run `npm test` in both `backend/` and `frontend/` before submitting a pull
+  request.
+
+## Branching Strategy
+- Work on feature branches created from `main` using the pattern
+  `feature/<description>` or `bugfix/<description>`.
+- Rebase frequently on top of `main` to minimize merge conflicts.
+- Push branches to the remote repository and open a pull request when ready.
+
+## Review Process
+- Ensure the Jenkins pipeline succeeds before requesting review: <https://jenkins.example.com/job/devops-deployment-system>
+- Provide a clear description of changes and reference any relevant issues.
+- At least one approval is required before merging.
+
+## Monitoring Links
+- Grafana dashboards for observability: <https://grafana.example.com/d/devops>
+
+Following these guidelines helps streamline collaboration and keeps the project
+healthy. Thank you for your contributions!

--- a/README.md
+++ b/README.md
@@ -1,16 +1,54 @@
-DevOps Kata
-- Build a deployment system with:
-  - Jenkins
-  - Helm
-  - OpenTofu
-  - Minikub or other kubernetes cluster manager
-  - Prometheus
-  - Prometheus
-  - Grafana
+# DevOps Kata
 
-You need to be able to deploy an application with all this tools and you need 2 clusters (or 2 namespaces).
-One for the infra an other for the apps that will be deployed. The pipelines in Jenkins need to run tests and fail if tests fail.
-OpenTofu need to have automated tests as well, all apps deploed need to be integrated with Grafana
-and Prometheus by default.
+This project demonstrates a simple deployment system for a sample application. It
+combines a React frontend with a Node.js backend and uses common DevOps tooling
+to automate infrastructure provisioning, application deployment, and
+observability.
 
+## Project Architecture
+- **Frontend:** React application served via a container image.
+- **Backend:** Node.js (Express) service exposing a REST API.
+- **CI/CD:** Jenkins pipelines build and test the application, then produce
+docker images.
+- **Infrastructure as Code:** OpenTofu provisions Kubernetes clusters or
+namespaces for infrastructure and application workloads.
+- **Deployment:** Helm charts deploy images to the target Kubernetes cluster.
+- **Monitoring:** Prometheus scrapes metrics and Grafana visualizes them through
+dashboards.
 
+## Setup Instructions
+1. **Prerequisites**
+   - Node.js 18+
+   - Docker and a local Kubernetes cluster (e.g. Minikube)
+   - Jenkins and OpenTofu installed locally or accessible remotely
+2. **Install dependencies**
+   ```bash
+   cd backend && npm install
+   cd ../frontend && npm install
+   ```
+3. **Run tests**
+   ```bash
+   npm test   # run inside both backend/ and frontend/
+   ```
+4. **Start services locally**
+   ```bash
+   cd backend && npm start
+   cd frontend && npm start
+   ```
+
+## Deployment Flow
+1. Code changes are pushed to the repository.
+2. Jenkins pipeline builds, tests, and packages the frontend and backend into
+   container images.
+3. OpenTofu provisions or updates the target Kubernetes infrastructure.
+4. Helm charts deploy the new images to the cluster.
+5. Prometheus and Grafana automatically begin monitoring the deployed
+   application.
+
+## Monitoring & Pipeline Links
+- Grafana dashboards: <https://grafana.example.com/d/devops>
+- Jenkins pipeline results: <https://jenkins.example.com/job/devops-deployment-system>
+
+## Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to
+this project.


### PR DESCRIPTION
## Summary
- document architecture, setup, deployment flow, and monitoring links
- add contributing guide covering coding standards and review process

## Testing
- `npm test` (backend)
- `npm test -- --watchAll=false` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68922a68110c832387f39804649b8ef7